### PR TITLE
fix for discriminator gradients setup in generator

### DIFF
--- a/feamgan/Experiment_Component/Trainer/ATrainer.py
+++ b/feamgan/Experiment_Component/Trainer/ATrainer.py
@@ -55,16 +55,16 @@ class ATrainer(ITrainer):
                 opt.step() if loss_is_valid else opt.zero_grad()
                 self.loss_index+=1
                 
-        return losses, pred 
+        return losses, pred
 
     def generator(self, data, model):
-        
+
         if self.mode == "train":
             generator_opts = model.module.getGeneratorOptimizers()
             discriminators = model.module.getDiscriminators()
             generators = model.module.getGenerators()
-            for dis in discriminators: 
-                for d in dis :self.toggleGrad(d, True)
+            for dis in discriminators:
+                for d in dis :self.toggleGrad(d, False)
             for gen in generators: self.toggleGrad(gen, True)
 
             for opt in generator_opts: opt.zero_grad()


### PR DESCRIPTION
Hello,

I have recently begun reviewing the code and noticed something that might be important for the training process. During the generator's training phase, should the gradients for the discriminator be disabled? This adjustment could potentially lead to improved training results.

Best regards,
Kamil